### PR TITLE
Improve the frontend

### DIFF
--- a/URLShortener/Views/Home/Error404.cshtml
+++ b/URLShortener/Views/Home/Error404.cshtml
@@ -1,5 +1,8 @@
 @{
-    ViewData["Title"] = "Page not found";
+    ViewData["Title"] = "Page Not Found";
 }
 
-<div>404</div>
+<div class="error-404">
+    <h1 class="error-404__title">Page Not Found</h1>
+    <p>Visit <a href="/">the home page</a> to shorten a URL</p>
+</div>

--- a/URLShortener/assets/js/Form/Output.jsx
+++ b/URLShortener/assets/js/Form/Output.jsx
@@ -33,7 +33,6 @@ export default ({response}) => {
     
     return (
         <div className="output">
-            <div className="output__short-url">{response.url}</div>
             <button
                 className={buttonClassNames}
                 type="button"
@@ -41,6 +40,9 @@ export default ({response}) => {
                 onClick={copyToClipboard}>
                 Copy to Clipboard
             </button>
+            <a href={response.url}
+               className="output__short-url"
+               target="_blank">{response.url}</a>
         </div>
     );
 };

--- a/URLShortener/assets/scss/app.scss
+++ b/URLShortener/assets/scss/app.scss
@@ -2,3 +2,4 @@
 @import "form";
 @import "user-input";
 @import "output";
+@import "error-404";

--- a/URLShortener/assets/scss/common.scss
+++ b/URLShortener/assets/scss/common.scss
@@ -20,3 +20,7 @@ body, .layout {
   display: flex;
   align-items: center;
 }
+
+a {
+  color: #4774e8;
+}

--- a/URLShortener/assets/scss/error-404.scss
+++ b/URLShortener/assets/scss/error-404.scss
@@ -1,0 +1,13 @@
+.error-404 {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-flow: column wrap;
+  width: 100vw;
+  height: 100vh;
+  
+  &__title {
+    margin-bottom: 1rem;
+    font-size: 2.5rem;
+  }
+}

--- a/URLShortener/assets/scss/output.scss
+++ b/URLShortener/assets/scss/output.scss
@@ -20,7 +20,6 @@
 
   &__short-url {
     font-size: 1.5rem;
-    color: #4774e8;
   }
   
   &__error {

--- a/URLShortener/assets/scss/output.scss
+++ b/URLShortener/assets/scss/output.scss
@@ -11,6 +11,7 @@
     overflow: hidden;
     background: url('../img/clipboard.svg') 0 -1px no-repeat;
     border: 0;
+    outline: none;
     cursor: pointer;
     
     &--ok {

--- a/URLShortener/assets/scss/output.scss
+++ b/URLShortener/assets/scss/output.scss
@@ -1,12 +1,7 @@
 .output {
   display: flex;
   flex-flow: row wrap;
-  justify-content: space-between;
   align-items: center;
-  
-  &__short-url {
-    font-size: 3rem;
-  }
 
   &__copy {
     width: 26px;
@@ -21,6 +16,11 @@
     &--ok {
       background-position: 0 -30px;
     }
+  }
+
+  &__short-url {
+    font-size: 1.5rem;
+    color: #4774e8;
   }
   
   &__error {


### PR DESCRIPTION
1. Style the 404 page
2. Decrease the font size 
3. Reorder elements in the result box
4. Remove the outline from the “Copy to Clipboard” button